### PR TITLE
[Feat] Header 컴포넌트 생성 & 다크모드 구현

### DIFF
--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -1,0 +1,41 @@
+#header {
+    background: var(--color-bg-dark);
+    padding: 0 20px;
+}
+
+.header {
+    max-width: 1060px;
+    margin: 0 auto;
+    height: 60px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.header h1 {
+    font-size: 24px;
+    color: #ff6636;
+}
+
+.header .header-right {
+    display: flex;
+    gap: 8px;
+}
+
+.header .btn-mode {
+    font-size: 1.5rem;
+    color: var(--color-text);
+    display: flex;
+    align-items: center;
+    padding: 4px;
+}
+
+.header .btn-mode:hover {
+    background: var(--color-btn-hover);
+    border-radius: 50%;
+    cursor: pointer;
+}
+
+.header .btn-login {
+    color: var(--color-text);
+}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -5,13 +5,14 @@ import styles from './Header.module.css';
 const cx = classnames.bind(styles);
 
 const Header = () => {
-    const { darkMode, toggleDarkMode } = useDarkMode();
+    const [darkMode, toggleDarkMode] = useDarkMode();
+    const handleToggle = () => toggleDarkMode();
     return (
         <header id={cx('header')}>
             <div className={cx('header')}>
                 <h1 className={cx('header-logo')}>DeBus</h1>
                 <div className={cx('header-right')}>
-                    <button className={cx('btn-mode')} onClick={toggleDarkMode}>
+                    <button className={cx('btn-mode')} onClick={handleToggle}>
                         {darkMode ? <IoMdMoon /> : <IoIosSunny />}
                     </button>
                     <button className={cx('btn-login')}>로그인</button>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,0 +1,24 @@
+import classnames from 'classnames/bind';
+import { IoIosSunny, IoMdMoon } from 'react-icons/io';
+import { useDarkMode } from 'src/context/DarkModeContext';
+import styles from './Header.module.css';
+const cx = classnames.bind(styles);
+
+const Header = () => {
+    const { darkMode, toggleDarkMode } = useDarkMode();
+    return (
+        <header id={cx('header')}>
+            <div className={cx('header')}>
+                <h1 className={cx('header-logo')}>DeBus</h1>
+                <div className={cx('header-right')}>
+                    <button className={cx('btn-mode')} onClick={toggleDarkMode}>
+                        {darkMode ? <IoIosSunny /> : <IoMdMoon />}
+                    </button>
+                    <button className={cx('btn-login')}>로그인</button>
+                </div>
+            </div>
+        </header>
+    );
+};
+
+export default Header;

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -12,7 +12,7 @@ const Header = () => {
                 <h1 className={cx('header-logo')}>DeBus</h1>
                 <div className={cx('header-right')}>
                     <button className={cx('btn-mode')} onClick={toggleDarkMode}>
-                        {darkMode ? <IoIosSunny /> : <IoMdMoon />}
+                        {darkMode ? <IoMdMoon /> : <IoIosSunny />}
                     </button>
                     <button className={cx('btn-login')}>로그인</button>
                 </div>

--- a/src/components/UI/RootContainer/RootContainer.module.css
+++ b/src/components/UI/RootContainer/RootContainer.module.css
@@ -1,0 +1,5 @@
+.container {
+    margin: 0 auto;
+    max-width: 1060px;
+    padding: 0 20px;
+}

--- a/src/components/UI/RootContainer/RootContainer.tsx
+++ b/src/components/UI/RootContainer/RootContainer.tsx
@@ -1,0 +1,10 @@
+import classnames from 'classnames/bind';
+import { PropsWithChildren } from 'react';
+import styles from './RootContainer.module.css';
+const cx = classnames.bind(styles);
+
+const RootContainer = ({ children }: PropsWithChildren) => {
+    return <div className={cx('container')}>{children}</div>;
+};
+
+export default RootContainer;

--- a/src/context/DarkModeContext.tsx
+++ b/src/context/DarkModeContext.tsx
@@ -1,0 +1,49 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+
+type State = {
+    darkMode: boolean;
+    toggleDarkMode: () => void;
+};
+
+const DarkModeContext = createContext<State | null>(null);
+
+export const DarkModeProvider = ({
+    children,
+}: {
+    children: React.ReactNode;
+}) => {
+    const [darkMode, setDarkMode] = useState(false);
+    const toggleDarkMode = () => {
+        setDarkMode(!darkMode);
+        updateDarkMode(!darkMode);
+    };
+    useEffect(() => {
+        const isDark =
+            localStorage.theme === 'dark' ||
+            (!('theme' in localStorage) &&
+                window.matchMedia('(prefers-color-scheme: dark)').matches);
+        setDarkMode(isDark);
+        updateDarkMode(isDark);
+    }, []);
+    return (
+        <DarkModeContext.Provider value={{ darkMode, toggleDarkMode }}>
+            {children}
+        </DarkModeContext.Provider>
+    );
+};
+
+export const useDarkMode = () => {
+    const state = useContext(DarkModeContext);
+    if (!state) throw new Error('Cannot find DarkModeProvider');
+    return state;
+};
+
+const updateDarkMode = (darkMode: boolean) => {
+    if (darkMode) {
+        document.documentElement.classList.add('dark');
+        localStorage.theme = 'dark';
+    } else {
+        document.documentElement.classList.remove('dark');
+        localStorage.theme = 'light';
+    }
+};

--- a/src/context/DarkModeContext.tsx
+++ b/src/context/DarkModeContext.tsx
@@ -1,32 +1,20 @@
-import { createContext, useContext, useEffect, useState } from 'react';
+import { DarkModeState, useTheme } from '@hooks/useTheme';
+import { PropsWithChildren, createContext, useContext, useEffect } from 'react';
 
-type State = {
-    darkMode: boolean;
-    toggleDarkMode: () => void;
-};
+const DarkModeContext = createContext<DarkModeState | null>(null);
 
-const DarkModeContext = createContext<State | null>(null);
-
-export const DarkModeProvider = ({
-    children,
-}: {
-    children: React.ReactNode;
-}) => {
-    const [darkMode, setDarkMode] = useState(false);
-    const toggleDarkMode = () => {
-        setDarkMode(!darkMode);
-        updateDarkMode(!darkMode);
-    };
+export const DarkModeProvider = ({ children }: PropsWithChildren) => {
+    const [darkMode, toggleDarkMode] = useTheme(false);
     useEffect(() => {
         const isDark =
             localStorage.theme === 'dark' ||
             (!('theme' in localStorage) &&
                 window.matchMedia('(prefers-color-scheme: dark)').matches);
-        setDarkMode(isDark);
-        updateDarkMode(isDark);
-    }, []);
+        toggleDarkMode(isDark);
+    }, [toggleDarkMode]);
+
     return (
-        <DarkModeContext.Provider value={{ darkMode, toggleDarkMode }}>
+        <DarkModeContext.Provider value={[darkMode, toggleDarkMode]}>
             {children}
         </DarkModeContext.Provider>
     );
@@ -36,14 +24,4 @@ export const useDarkMode = () => {
     const state = useContext(DarkModeContext);
     if (!state) throw new Error('Cannot find DarkModeProvider');
     return state;
-};
-
-const updateDarkMode = (darkMode: boolean) => {
-    if (darkMode) {
-        document.documentElement.classList.add('dark');
-        localStorage.theme = 'dark';
-    } else {
-        document.documentElement.classList.remove('dark');
-        localStorage.theme = 'light';
-    }
 };

--- a/src/context/DarkModeContext.tsx
+++ b/src/context/DarkModeContext.tsx
@@ -1,18 +1,10 @@
 import { DarkModeState, useTheme } from '@hooks/useTheme';
-import { PropsWithChildren, createContext, useContext, useEffect } from 'react';
+import { PropsWithChildren, createContext, useContext } from 'react';
 
 const DarkModeContext = createContext<DarkModeState | null>(null);
 
 export const DarkModeProvider = ({ children }: PropsWithChildren) => {
     const [darkMode, toggleDarkMode] = useTheme(false);
-    useEffect(() => {
-        const isDark =
-            localStorage.theme === 'dark' ||
-            (!('theme' in localStorage) &&
-                window.matchMedia('(prefers-color-scheme: dark)').matches);
-        toggleDarkMode(isDark);
-    }, [toggleDarkMode]);
-
     return (
         <DarkModeContext.Provider value={[darkMode, toggleDarkMode]}>
             {children}

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,13 +1,23 @@
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 export type DarkModeState = [boolean, (localTheme?: boolean) => void];
 
 export const useTheme = (initialState: boolean = false): DarkModeState => {
     const [darkMode, setDarkMode] = useState(initialState);
-    const toggleDarkMode = (localTheme?: boolean) => {
-        setDarkMode(localTheme ?? !darkMode);
-        updateDarkMode(localTheme ?? !darkMode);
-    };
+    const toggleDarkMode = useCallback(
+        (localTheme?: boolean) => {
+            setDarkMode(localTheme ?? !darkMode);
+            updateDarkMode(localTheme ?? !darkMode);
+        },
+        [darkMode],
+    );
+    useEffect(() => {
+        const isDark =
+            localStorage.theme === 'dark' ||
+            (!('theme' in localStorage) &&
+                window.matchMedia('(prefers-color-scheme: dark)').matches);
+        toggleDarkMode(isDark);
+    }, [toggleDarkMode]);
     return [darkMode, toggleDarkMode];
 };
 

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+
+export type DarkModeState = [boolean, (localTheme?: boolean) => void];
+
+export const useTheme = (initialState: boolean = false): DarkModeState => {
+    const [darkMode, setDarkMode] = useState(initialState);
+    const toggleDarkMode = (localTheme?: boolean) => {
+        setDarkMode(localTheme ?? !darkMode);
+        updateDarkMode(localTheme ?? !darkMode);
+    };
+    return [darkMode, toggleDarkMode];
+};
+
+const updateDarkMode = (darkMode: boolean) => {
+    if (darkMode) {
+        document.documentElement.classList.add('dark');
+        localStorage.theme = 'dark';
+    } else {
+        document.documentElement.classList.remove('dark');
+        localStorage.theme = 'light';
+    }
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,31 @@
+@import url(//spoqa.github.io/spoqa-han-sans/css/SpoqaHanSansNeo.css);
+@import './reset.css';
+
+:root {
+    --color-bg: #fdfffd;
+    --color-white: white;
+    --color-text: #1d2026;
+    --color-gray-900: #1d2026;
+    --color-accent: #ff6636;
+}
+
+html.dark {
+    --color-bg: #1d2026;
+    --color-text: white;
+    --color-gray-900: white;
+}
+
+* {
+    font-family: 'Spoqa Han Sans Neo', 'sans-serif';
+    box-sizing: border-box;
+}
+
+body {
+    background: var(--color-bg);
+}
+
+#root {
+    width: 100%;
+    max-width: 1060px;
+    margin: 0 auto;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -20,7 +20,7 @@ html.dark {
 }
 
 * {
-    font-family: 'Spoqa Han Sans Neo', 'sans-serif';
+    font-family: 'Spoqa Han Sans Neo', sans-serif;
     box-sizing: border-box;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -3,16 +3,20 @@
 
 :root {
     --color-bg: #fdfffd;
+    --color-bg-dark: white;
     --color-white: white;
     --color-text: #1d2026;
     --color-gray-900: #1d2026;
     --color-accent: #ff6636;
+    --color-btn-hover: #1d202610;
 }
 
 html.dark {
     --color-bg: #1d2026;
+    --color-bg-dark: #191b20;
     --color-text: white;
     --color-gray-900: white;
+    --color-btn-hover: #ffffff10;
 }
 
 * {
@@ -25,7 +29,5 @@ body {
 }
 
 #root {
-    width: 100%;
-    max-width: 1060px;
-    margin: 0 auto;
+    color: var(--color-text);
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,5 @@
 import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
+import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(<App />);

--- a/src/pages/Root.tsx
+++ b/src/pages/Root.tsx
@@ -1,11 +1,16 @@
+import Header from '@components/Header/Header';
+import RootContainer from '@components/UI/RootContainer/RootContainer';
 import { Outlet } from 'react-router-dom';
+import { DarkModeProvider } from 'src/context/DarkModeContext';
 
 const Root = () => {
     return (
-        <>
-            <h1>공통 레이아웃</h1>
-            <Outlet />
-        </>
+        <DarkModeProvider>
+            <Header />
+            <RootContainer>
+                <Outlet />
+            </RootContainer>
+        </DarkModeProvider>
     );
 };
 

--- a/src/reset.css
+++ b/src/reset.css
@@ -1,0 +1,123 @@
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+    display: block;
+}
+body {
+    line-height: 1;
+}
+ol,
+ul {
+    list-style: none;
+}
+blockquote,
+q {
+    quotes: none;
+}
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+    content: '';
+    content: none;
+}
+table {
+    border-collapse: collapse;
+    border-spacing: 0;
+}

--- a/src/reset.css
+++ b/src/reset.css
@@ -121,3 +121,12 @@ table {
     border-collapse: collapse;
     border-spacing: 0;
 }
+button {
+    background: inherit;
+    border: none;
+    box-shadow: none;
+    border-radius: 0;
+    padding: 0;
+    overflow: visible;
+    cursor: pointer;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,8 @@
         "baseUrl": ".", // baseUrl을 기준으로 관련된 위치에 모듈 이름의 경로 매핑 목록을 나열한다.
         "paths": {
             "@components/*": ["./src/components/*"],
-            "@pages/*": ["./src/pages/*"]
+            "@pages/*": ["./src/pages/*"],
+            "@hooks/*": ["./src/hooks/*"]
         }
     },
     "include": ["src"],


### PR DESCRIPTION
## PR 타입
- [X] UI
- [X] 기능 추가

## 작업 내용
1. CSS 초기 설정

2. `RootContainer` 컴포넌트
   - 여백을 유지하면서 Header에 전체 background color 적용을 위한 레이아웃 분리
   - `Page` 컴포넌트에 CSS module 파일을 생성하지 않고 UI 컴포넌트로 작성

3. `Header` 컴포넌트
   - 다크모드 전환 토글 버튼

4. 다크모드 구현
   - ContextAPI
   - Custom Hook
   - 모드 전환에 따라 CSS 클래스 변경 & 테마 정보 저장

## 스크린샷
<img width="1438" alt="feat_2(1)" src="https://github.com/f-lab-edu/debus/assets/93242226/69ea145c-60d9-47d5-8eb9-e95781e84900">
<img width="1438" alt="feat_2" src="https://github.com/f-lab-edu/debus/assets/93242226/f8f2ab0b-acee-48c1-9d34-df918bda7d72">