### PR TITLE
[#14] 모달을 이용한 채팅방 생성 구현 및 TanStack-Query 서버 상태 관리

### DIFF
--- a/src/@types/chatRoom.ts
+++ b/src/@types/chatRoom.ts
@@ -1,0 +1,33 @@
+export type ChatRoomInfo = {
+    title: string;
+    desc: string;
+    options: string;
+};
+
+type ChatRoomStatus = 'pending' | 'running';
+
+export type ChatRoomInfoType = {
+    id: string;
+    title: string;
+    desc: string;
+    options: string[];
+    createAt: number;
+    members: Member[];
+    status: ChatRoomStatus;
+};
+
+export type Member = {
+    userId: string;
+    name: string;
+    role: string;
+};
+
+export type Message = {
+    id: string;
+    content: string;
+    timestamp: unknown;
+    user: {
+        id?: string;
+        name: string;
+    };
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,7 @@
 import Header from '@components/Header/Header';
 import { darkModeAtom } from '@store/atoms/theme';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { useAtomValue } from 'jotai';
 import moment from 'moment';
 import 'moment/dist/locale/ko';
@@ -8,17 +10,21 @@ import { ModalProvider } from 'src/context/ModalContext';
 
 moment.locale('ko');
 
+export const queryClient = new QueryClient();
+
 function App() {
     const darkMode = useAtomValue(darkModeAtom);
-
     return (
         <ModalProvider>
-            <div id="app" className={darkMode ? 'dark' : 'light'}>
-                <Header />
-                <div className="container">
-                    <Outlet />
+            <QueryClientProvider client={queryClient}>
+                <div id="app" className={darkMode ? 'dark' : 'light'}>
+                    <Header />
+                    <div className="container">
+                        <Outlet />
+                    </div>
                 </div>
-            </div>
+                <ReactQueryDevtools initialIsOpen={true} />
+            </QueryClientProvider>
         </ModalProvider>
     );
 }

--- a/src/api/firebase.ts
+++ b/src/api/firebase.ts
@@ -56,7 +56,10 @@ const createUser = (user: UserTypes) => {
 const checkChatRoomExists = async (chatRoomId: string) =>
     get(ref(db, `lines/${chatRoomId}`)).then((snapshot) => snapshot.exists());
 
-export const createChatRoom: MutationFunction<string, [UserTypes, ChatRoomInfo]> = async ([user, chatRoomInfo]) => {
+export const createChatRoom: MutationFunction<string, { user: UserTypes; chatRoomInfo: ChatRoomInfo }> = async ({
+    user,
+    chatRoomInfo,
+}) => {
     const id = nanoid();
     const isExistingChatroom = await checkChatRoomExists(id);
     if (isExistingChatroom) {

--- a/src/components/@common/Modal/ModalContents/CreateChatRoom/CreateChatRoomModal.tsx
+++ b/src/components/@common/Modal/ModalContents/CreateChatRoom/CreateChatRoomModal.tsx
@@ -1,0 +1,25 @@
+import Button from '@components/@common/Button/Button';
+import Form, { ChatRoomInfo } from '@components/@common/Modal/ModalContents/CreateChatRoom/Form/Form';
+import ModalButtonGroup from '@components/@common/Modal/ModalTemplate/ModalButtonGroup';
+import ModalContent from '@components/@common/Modal/ModalTemplate/ModalContent';
+import ModalHeader from '@components/@common/Modal/ModalTemplate/ModalHeader';
+import ModalTemplate from '@components/@common/Modal/ModalTemplate/ModalTemplate';
+import { ModalContentProps } from 'src/@types/modal';
+
+const CreateChatRoomModal = ({ onSubmit, onAbort }: ModalContentProps<ChatRoomInfo>) => {
+    return (
+        <ModalTemplate onClose={onAbort} isOverlay={true}>
+            <ModalHeader title={'채팅방 생성'} onClose={onAbort} />
+            <ModalContent>
+                <Form onSubmit={onSubmit}>
+                    <ModalButtonGroup>
+                        <Button text="방만들기" variant="accent" type="submit" />
+                        <Button text="취소" variant="default" onClick={onAbort} />
+                    </ModalButtonGroup>
+                </Form>
+            </ModalContent>
+        </ModalTemplate>
+    );
+};
+
+export default CreateChatRoomModal;

--- a/src/components/@common/Modal/ModalContents/CreateChatRoom/Form/Form.module.css
+++ b/src/components/@common/Modal/ModalContents/CreateChatRoom/Form/Form.module.css
@@ -1,0 +1,17 @@
+.form-container {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.form-container input {
+    font-size: 1rem;
+    border: 1px solid #d1c1b5;
+    border-radius: 8px;
+    padding: 12px;
+}
+
+.error-msg {
+    font-size: 0.8rem;
+    color: rgb(255, 64, 0);
+}

--- a/src/components/@common/Modal/ModalContents/CreateChatRoom/Form/Form.tsx
+++ b/src/components/@common/Modal/ModalContents/CreateChatRoom/Form/Form.tsx
@@ -1,0 +1,58 @@
+import classnames from 'classnames/bind';
+import { PropsWithChildren, memo } from 'react';
+import { useForm } from 'react-hook-form';
+import styles from './Form.module.css';
+const cx = classnames.bind(styles);
+
+export type ChatRoomInfo = {
+    title: string;
+    desc: string;
+    options: string;
+};
+
+const Form = ({
+    children,
+    onSubmit,
+}: PropsWithChildren & { onSubmit: (newChatRoom: ChatRoomInfo) => Promise<void> | void }) => {
+    const {
+        register,
+        handleSubmit,
+        formState: { errors },
+    } = useForm<ChatRoomInfo>({ mode: 'onSubmit' });
+
+    return (
+        <form className={cx('form-container')} onSubmit={handleSubmit(onSubmit)}>
+            <label htmlFor="title">방 제목</label>
+            <input
+                id="title"
+                type="text"
+                {...register('title', {
+                    required: true,
+                    minLength: {
+                        value: 2,
+                        message: '2글자 이상 입력해주세요.',
+                    },
+                })}
+            />
+            <p className={cx('error-msg')}>{errors.title?.message}</p>
+
+            <label htmlFor="desc">설명</label>
+            <input
+                type="text"
+                {...register('desc', {
+                    required: true,
+                    minLength: {
+                        value: 5,
+                        message: '5글자 이상 입력해주세요.',
+                    },
+                })}
+            />
+            <p className={cx('error-msg')}>{errors.desc?.message}</p>
+            <label htmlFor="options">옵션</label>
+            <input type="text" {...register('options')} placeholder=",(콤마)로 구분해주세요." />
+            {children}
+        </form>
+    );
+};
+
+export default memo(Form);

--- a/src/components/Section/ChatRooms/ChatRooms.tsx
+++ b/src/components/Section/ChatRooms/ChatRooms.tsx
@@ -19,8 +19,8 @@ const ChatRooms = () => {
 
     const handleCreate = async () => {
         try {
-            const result = await openModal(CreateChatRoomModal);
-            mutate([user, result]);
+            const chatRoomInfo = await openModal(CreateChatRoomModal);
+            mutate({ user, chatRoomInfo });
         } catch (err) {
             console.log('모달 닫습니다~!');
         }

--- a/src/components/Section/ChatRooms/ChatRooms.tsx
+++ b/src/components/Section/ChatRooms/ChatRooms.tsx
@@ -1,0 +1,43 @@
+import Button from '@components/@common/Button/Button';
+import CreateChatRoomModal from '@components/@common/Modal/ModalContents/CreateChatRoom/CreateChatRoomModal';
+import { useModal } from '@hooks/useModal';
+import { UserTypes, authAtom } from '@store/atoms/auth';
+import { useMutation } from '@tanstack/react-query';
+import { useAtomValue } from 'jotai';
+import { useNavigate } from 'react-router-dom';
+import { ChatRoomInfo } from 'src/@types/chatRoom';
+import { createChatRoom } from 'src/api/firebase';
+
+const ChatRooms = () => {
+    const user = useAtomValue(authAtom);
+    const { openModal, renderModal } = useModal();
+    const navigate = useNavigate();
+    const { mutate } = useMutation({
+        mutationFn: async ({ userId, result }: { userId: UserTypes | null; result: ChatRoomInfo }) =>
+            await createChatRoom(userId, result),
+        onSuccess: (id) => navigate(`/lines/${id}`),
+    });
+
+    const handleCreate = async () => {
+        try {
+            const result = await openModal(CreateChatRoomModal);
+            mutate({ userId: user, result });
+        } catch (err) {
+            console.log('모달 닫습니다~!');
+        }
+    };
+
+    return (
+        <>
+            <section>
+                <h1>정류장</h1>
+                <nav>
+                    <Button text="배차하기" variant="accent" onClick={handleCreate} />
+                </nav>
+            </section>
+            {renderModal()}
+        </>
+    );
+};
+
+export default ChatRooms;

--- a/src/components/Section/ChatRooms/ChatRooms.tsx
+++ b/src/components/Section/ChatRooms/ChatRooms.tsx
@@ -1,27 +1,26 @@
 import Button from '@components/@common/Button/Button';
 import CreateChatRoomModal from '@components/@common/Modal/ModalContents/CreateChatRoom/CreateChatRoomModal';
 import { useModal } from '@hooks/useModal';
-import { UserTypes, authAtom } from '@store/atoms/auth';
+import { authAtom } from '@store/atoms/auth';
 import { useMutation } from '@tanstack/react-query';
 import { useAtomValue } from 'jotai';
 import { useNavigate } from 'react-router-dom';
-import { ChatRoomInfo } from 'src/@types/chatRoom';
 import { createChatRoom } from 'src/api/firebase';
 
 const ChatRooms = () => {
-    const user = useAtomValue(authAtom);
+    const user = useAtomValue(authAtom)!;
     const { openModal, renderModal } = useModal();
     const navigate = useNavigate();
     const { mutate } = useMutation({
-        mutationFn: async ({ userId, result }: { userId: UserTypes | null; result: ChatRoomInfo }) =>
-            await createChatRoom(userId, result),
+        mutationFn: createChatRoom,
         onSuccess: (id) => navigate(`/lines/${id}`),
+        onError: (err) => console.log(err),
     });
 
     const handleCreate = async () => {
         try {
             const result = await openModal(CreateChatRoomModal);
-            mutate({ userId: user, result });
+            mutate([user, result]);
         } catch (err) {
             console.log('모달 닫습니다~!');
         }

--- a/src/components/chatRoom/SidePanel/ChatMembers/ChatMembers.tsx
+++ b/src/components/chatRoom/SidePanel/ChatMembers/ChatMembers.tsx
@@ -1,20 +1,18 @@
-import { chatRoomAtom } from '@store/atoms/chatRoom';
+import { Member } from '@store/atoms/chatRoom';
 import classnames from 'classnames/bind';
-import { useAtomValue } from 'jotai';
+import { memo } from 'react';
 import { FaCrown } from 'react-icons/fa';
 import styles from './ChatMembers.module.css';
 const cx = classnames.bind(styles);
+const userId = 'def';
 
-const ChatMembers = () => {
-    const { members: memberList } = useAtomValue(chatRoomAtom);
-    const userId = 'def';
-
+const ChatMembers = ({ members }: { members: Member[] }) => {
     return (
         <div className={cx('container')}>
-            <h1>참여 ({memberList?.length})</h1>
+            <h1>참여 ({members?.length})</h1>
             <ul>
-                {memberList &&
-                    memberList.map((member) => (
+                {members &&
+                    members.map((member) => (
                         <li key={member.userId} className={cx('item')}>
                             {member.name}
                             {member.role === 'owner' && <FaCrown className={cx('icon')} />}
@@ -26,4 +24,4 @@ const ChatMembers = () => {
     );
 };
 
-export default ChatMembers;
+export default memo(ChatMembers);

--- a/src/components/chatRoom/SidePanel/ChatRoomHeader/ChatRoomHeader.tsx
+++ b/src/components/chatRoom/SidePanel/ChatRoomHeader/ChatRoomHeader.tsx
@@ -1,27 +1,20 @@
-import { chatRoomAtom } from '@store/atoms/chatRoom';
+import { ChatRoomInfoType } from '@store/atoms/chatRoom';
 import classnames from 'classnames/bind';
-import { useAtomValue } from 'jotai';
+import { memo } from 'react';
 import styles from './ChatRoomHeader.module.css';
 const cx = classnames.bind(styles);
 
-const ChatRoomHeader = () => {
-    const chatRoomInfo = useAtomValue(chatRoomAtom);
+const ChatRoomHeader = ({ chatRoom }: { chatRoom: ChatRoomInfoType }) => {
     return (
         <div className={cx('container')}>
-            <h1>No. {chatRoomInfo.id}</h1>
+            <h1>No. {[...chatRoom.id.slice(0, 5)]}</h1>
             <div className={cx('divider')}></div>
-            <p className={cx('title')}>
-                {chatRoomInfo.title} 제목은 길면 잘려요
-            </p>
-            <p className={cx('desc')}>{chatRoomInfo.desc}</p>
+            <p className={cx('title')}>{chatRoom.title}</p>
+            <p className={cx('desc')}>{chatRoom.desc}</p>
             <div className={cx('divider')}></div>
-            <ul>
-                {chatRoomInfo.options.map((option) => (
-                    <li key={option}>- {option}</li>
-                ))}
-            </ul>
+            <ul>{chatRoom.options && chatRoom.options.map((option) => <li key={option}>{option}</li>)}</ul>
         </div>
     );
 };
 
-export default ChatRoomHeader;
+export default memo(ChatRoomHeader);

--- a/src/components/chatRoom/SidePanel/SidePanel.tsx
+++ b/src/components/chatRoom/SidePanel/SidePanel.tsx
@@ -1,16 +1,38 @@
-import ChatMembers from '@components/chatRoom/SidePanel/ChatMembers/ChatMembers';
-import ChatRoomHeader from '@components/chatRoom/SidePanel/ChatRoomHeader/ChatRoomHeader';
+import ChatMembers from '@components/ChatRoom/SidePanel/ChatMembers/ChatMembers';
+import ChatRoomHeader from '@components/ChatRoom/SidePanel/ChatRoomHeader/ChatRoomHeader';
+import { useQuery } from '@tanstack/react-query';
 import classnames from 'classnames/bind';
+import { memo } from 'react';
+import { queryKeys } from 'src/queries';
+import { assert } from 'src/utils/assert';
 import styles from './SidePanel.module.css';
 const cx = classnames.bind(styles);
 
-const SidePanel = () => {
+const SidePanel = ({ id }: { id: string }) => {
+    const {
+        data: chatRoom,
+        isLoading,
+        isError,
+    } = useQuery({
+        ...queryKeys.chatRooms.detail(id),
+        staleTime: 5 * 1000,
+    });
+
+    if (isLoading) {
+        return <strong>채팅방을 불러오는 중입니다.</strong>;
+    }
+
+    assert(chatRoom !== undefined, '채팅방 정보가 존재하지 않습니다.');
+    const { members } = chatRoom;
+    if (isError) {
+        return <strong>Error 발생! 잠시 후 다시 시도해주세요.</strong>;
+    }
     return (
         <div className={cx('container')}>
-            <ChatRoomHeader />
-            <ChatMembers />
+            <ChatRoomHeader chatRoom={chatRoom} />
+            <ChatMembers members={members} />
         </div>
     );
 };
 
-export default SidePanel;
+export default memo(SidePanel);

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -1,5 +1,11 @@
+import ChatRooms from '@components/Section/ChatRooms/ChatRooms';
+
 const HomePage = () => {
-    return <div>Home</div>;
+    return (
+        <>
+            <ChatRooms />
+        </>
+    );
 };
 
 export default HomePage;

--- a/src/pages/LinePage/LinePage.tsx
+++ b/src/pages/LinePage/LinePage.tsx
@@ -1,54 +1,33 @@
-import ChatPanel from '@components/chatRoom/ChatPanel/ChatPanel';
-import SidePanel from '@components/chatRoom/SidePanel/SidePanel';
-import { chatRoomAtom } from '@store/atoms/chatRoom';
+import Loading from '@components/@common/Loading/Loading';
+import ChatPanel from '@components/ChatRoom/ChatPanel/ChatPanel';
+import SidePanel from '@components/ChatRoom/SidePanel/SidePanel';
+import { currentChatRoom } from '@store/atoms/chatRoom';
 import classnames from 'classnames/bind';
-import { useSetAtom } from 'jotai';
-import { useEffect } from 'react';
+import { useAtom } from 'jotai';
+import { Suspense, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { assert } from 'src/utils/assert';
 import styles from './LinePage.module.css';
 const cx = classnames.bind(styles);
 
 const LinePage = () => {
-    const setChatRoomInfo = useSetAtom(chatRoomAtom);
+    const [currentChatRoomId, setCurrentChatRoomId] = useAtom(currentChatRoom);
+    const { id } = useParams();
+    assert(id !== undefined, '채팅방 id가 존재하지 않습니다.');
+
     useEffect(() => {
-        setChatRoomInfo({
-            id: '1',
-            title: '같이 공부해요',
-            desc: '리액트 뿌시기!',
-            options: ['Javascript', 'FE', '경력무관'],
-            createAt: new Date().getTime(),
-            members: [
-                {
-                    userId: 'abc',
-                    name: '한찌',
-                    role: 'owner',
-                },
-                {
-                    userId: 'def',
-                    name: '두찌',
-                    role: 'none',
-                },
-                {
-                    userId: 'seafe',
-                    name: '세찌',
-                    role: 'none',
-                },
-                {
-                    userId: 'fwgew',
-                    name: '네찌',
-                    role: 'none',
-                },
-            ],
-            status: 'pending',
-        });
-    }, [setChatRoomInfo]);
+        setCurrentChatRoomId(id);
+    }, [id, setCurrentChatRoomId]);
 
     return (
         <div className={cx('container')}>
             <div className={cx('side')}>
-                <SidePanel />
+                <SidePanel id={currentChatRoomId} />
             </div>
             <div className={cx('chat')}>
-                <ChatPanel />
+                <Suspense fallback={<Loading />}>
+                    <ChatPanel id={currentChatRoomId} />
+                </Suspense>
             </div>
         </div>
     );

--- a/src/queries/chatRoom.ts
+++ b/src/queries/chatRoom.ts
@@ -1,0 +1,9 @@
+import { createQueryKeys } from '@lukemorales/query-key-factory';
+import { getChatRoom } from 'src/api/firebase';
+
+export const chatRoomsKeys = createQueryKeys('chatRooms', {
+    detail: (chatRoomId: string) => ({
+        queryKey: [chatRoomId],
+        queryFn: () => getChatRoom(chatRoomId),
+    }),
+});

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -1,0 +1,4 @@
+import { mergeQueryKeys } from '@lukemorales/query-key-factory';
+import { chatRoomsKeys } from 'src/queries/chatRoom';
+
+export const queryKeys = mergeQueryKeys(chatRoomsKeys);

--- a/src/store/atoms/chatRoom.ts
+++ b/src/store/atoms/chatRoom.ts
@@ -8,22 +8,14 @@ export type ChatRoomInfoType = {
     desc: string;
     options: string[];
     createAt: number;
-    members: {
-        userId: string;
-        name: string;
-        role: string;
-    }[];
+    members: Member[];
     status: ChatRoomStatus;
 };
 
-const initialState: ChatRoomInfoType = {
-    id: '',
-    title: '',
-    desc: '',
-    options: [],
-    createAt: 0,
-    members: [],
-    status: 'pending',
+export type Member = {
+    userId: string;
+    name: string;
+    role: string;
 };
 
-export const chatRoomAtom = atom(initialState);
+export const currentChatRoom = atom('');


### PR DESCRIPTION
## PR 타입
- [X] 기능 추가
- [X] 코드 개선

## 전달사항
- 메시지를 주고 받는 `ChatPanel`은 다음 이슈로 진행하겠습니다.

## 작업 내용
### 최종 모달을 이용한 채팅방 생성 구현

1. `TanStack-Query` 도입 
2. `Section`으로 재사용 가능한 컴포넌트 파일 분리
3. 채팅방 생성 컴포넌트 구현
4. 채팅방 생성 api 작성
   - 이미 존재하는 채팅방 확인 로직 추가
5. `Query Key Factory` 라이브러리를 이용한 `Query Key` 관리
6. 채팅방 생성 후 진입 과정과 관련된 컴포넌트 서버 상태 관리

## 설명
- 채팅방 `Section`을 통해 `방만들기`를 하면 모달이 열립니다. 
- 채팅방이 생성되면 `/lines/:id` 경로로 라우팅 됩니다.
- `LinePage`에서는 채팅방 id를 이용해 상태를 저장합니다.
- `SidePanel`에서는 id를 props으로 받아 데이터를 캐싱하여 하위 컴포넌트로 전달합니다.


## 관련 이슈
close #14